### PR TITLE
Add SQL preprocessor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Sardine looks up for a `sardineConfig.js` file in the current directory.
     database: 'postgres',
   },
   path: '/usr/local/mybase.sqlite', // Only used for sqlite3
+  preprocess: (content, path) => content, // Optional SQL preprocessing function.
+                                          // Takes content and path of a SQL file.
+                                          // Returns the actual SQL code to be executed.
+                                          // Default: identity function.
 };
 ```
 

--- a/lib/migrations.jsx
+++ b/lib/migrations.jsx
@@ -10,8 +10,14 @@ import Finder from './finder';
 import Model from './db/model';
 
 class Migrations extends EventEmitter {
+  DEFAULT_CONFIG = {
+    preprocess: _.identity,
+  };
+
   constructor(config) {
     super();
+
+    config = _.defaults(config, this.DEFAULT_CONFIG);
 
     this.config = config;
     this.model = new Model(config);
@@ -93,7 +99,7 @@ class Migrations extends EventEmitter {
       this.emit(events.APPLY_STEP, path);
       return {
         path,
-        sql: file.contents.toString(),
+        sql: this.config.preprocess(file.contents.toString(), path),
       };
     });
 


### PR DESCRIPTION
New config option: `preprocess`, a function that may alter the SQL code
(content of the SQL files) at runtime, just before it is executed.
The function is executed once for each SQL file of a migration.
It takes as parameters the content of the file (the SQL code) and
the relative file path, and returns the processed SQL code.

An example usage of this feature is the replacement of placeholders by
their actual values.

The default value of `preprocess` is the identity function.